### PR TITLE
made jhbuild more cross-platform

### DIFF
--- a/jhbuild/defaults.jhbuildrc
+++ b/jhbuild/defaults.jhbuildrc
@@ -68,7 +68,11 @@ cflags = ''
 
 # a alternative install program to use; the included install-check
 # program won't update timestamps if the header hasn't changed
-installprog = os.path.join(os.environ['HOME'], '.local/bin', 'install-check')
+installprog = os.path.join(
+	os.path.expanduser("~"),
+	'.local/bin',
+	'install-check'
+)
 if not os.path.exists(installprog):
     installprog = '/usr/bin/install-check'
 if not os.path.exists(installprog):

--- a/jhbuild/defaults.jhbuildrc
+++ b/jhbuild/defaults.jhbuildrc
@@ -4,6 +4,7 @@
 
 import os, sys, tempfile
 
+
 if 'GTK_PATH' in os.environ.keys():
     del os.environ['GTK_PATH']
 
@@ -12,7 +13,7 @@ modulesets_dir = os.path.join(SRCDIR, 'modulesets')
 
 # what modules to build?
 moduleset = 'gnome-apps-3.10'
-modules = [ 'meta-gnome-core' ]
+modules = ['meta-gnome-core']
 
 # policy for modules to build, options are:
 #  - all: build everything requested

--- a/jhbuild/monkeypatch.py
+++ b/jhbuild/monkeypatch.py
@@ -26,13 +26,6 @@ if sys.platform.startswith('win'):
     from jhbuild.utils import subprocess_win32
     sys.modules['subprocess'] = subprocess_win32
 
-# Python < 2.4 lacks reversed() builtin
-if not hasattr(__builtin__, 'reversed'):
-    def reversed(l):
-        l = list(l)
-        l.reverse()
-        return iter(l)
-    __builtin__.reversed = reversed
 
 # Python < 2.4 lacks string.Template class
 import string
@@ -163,10 +156,3 @@ if not hasattr(string, 'Template'):
             return self.pattern.sub(convert, self.template)
 
     string.Template = Template
-
-# Python < 2.4 lacks subprocess module
-try:
-    import subprocess
-except ImportError:
-    from jhbuild.cut_n_paste import subprocess
-    sys.modules['subprocess'] = subprocess

--- a/jhbuild/monkeypatch.py
+++ b/jhbuild/monkeypatch.py
@@ -20,6 +20,7 @@
 import sys
 import __builtin__
 
+
 # Windows lacks all sorts of subprocess features that we need to kludge around
 if sys.platform.startswith('win'):
     from jhbuild.utils import subprocess_win32
@@ -169,4 +170,3 @@ try:
 except ImportError:
     from jhbuild.cut_n_paste import subprocess
     sys.modules['subprocess'] = subprocess
-        

--- a/jhbuild/utils/httpcache.py
+++ b/jhbuild/utils/httpcache.py
@@ -39,11 +39,11 @@ try:
     import gzip
 except ImportError:
     gzip = None
-
 try:
     import xml.dom.minidom
 except ImportError:
     raise SystemExit, _('Python XML packages are required but could not be found')
+
 
 def _parse_isotime(string):
     if string[-1] != 'Z':
@@ -51,14 +51,17 @@ def _parse_isotime(string):
     tm = time.strptime(string, '%Y-%m-%dT%H:%M:%SZ')
     return time.mktime(tm[:8] + (0,)) - time.timezone    
 
+
 def _format_isotime(tm):
     return time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(tm))
+
 
 def _parse_date(date):
     tm = rfc822.parsedate_tz(date)
     if tm:
         return rfc822.mktime_tz(tm)
     return 0
+
 
 class CacheEntry:
     def __init__(self, uri, local, modified, etag, expires=0):
@@ -67,6 +70,7 @@ class CacheEntry:
         self.modified = modified
         self.etag = etag
         self.expires = expires
+
 
 class Cache:
     try:
@@ -232,6 +236,7 @@ class Cache:
         self.entries[uri] = entry
         self.write_cache()
         return filename
+
 
 _cache = None
 def load(uri, nonetwork=False, age=None):

--- a/jhbuild/utils/httpcache.py
+++ b/jhbuild/utils/httpcache.py
@@ -33,8 +33,14 @@ import sys
 import urllib2
 import urlparse
 import time
-import rfc822
-import StringIO
+try:
+    from email.utils import parsedate_tz, mktime_tz
+except ImportError:
+    from rfc822 import parsedate_tz, mktime_tz
+try:
+    from cStringIO import StringIO
+except ImportError:
+	from StringIO import StringIO
 try:
     import gzip
 except ImportError:
@@ -57,9 +63,9 @@ def _format_isotime(tm):
 
 
 def _parse_date(date):
-    tm = rfc822.parsedate_tz(date)
+    tm = parsedate_tz(date)
     if tm:
-        return rfc822.mktime_tz(tm)
+        return mktime_tz(tm)
     return 0
 
 

--- a/jhbuild/utils/httpcache.py
+++ b/jhbuild/utils/httpcache.py
@@ -50,6 +50,8 @@ try:
 except ImportError:
     raise SystemExit, _('Python XML packages are required but could not be found')
 
+from appdirs import user_cache_dir
+
 
 def _parse_isotime(string):
     if string[-1] != 'Z':
@@ -79,10 +81,7 @@ class CacheEntry:
 
 
 class Cache:
-    try:
-        cachedir = os.path.join(os.environ['XDG_CACHE_HOME'], 'jhbuild')
-    except KeyError:
-        cachedir = os.path.join(os.environ['HOME'], '.cache','jhbuild')
+    cachedir = user_cache_dir("jhbuild", "Gnome")
 
     # default to a 6 hour expiry time.
     default_age = 6 * 60 * 60


### PR DESCRIPTION
Replaced some direct os environment variable querying with their equivalent cross-platform solutions.

Added a dependency on appdirs to take care of finding the right caching folder, in a cross-platform way.

Removed some legacy code from the monkeypatch (might need more work).

As a bonus, in the files I worked in, I tried to improved pep8 compliance by cleaning up some simple whitespace issues.
